### PR TITLE
Sort ProvisionedDevices

### DIFF
--- a/normalize-profile
+++ b/normalize-profile
@@ -80,6 +80,8 @@ try:
         cert = plist.pop("DER-Encoded-Profile")
         cert = hashlib.sha256(cert).hexdigest()
         plist["DER-Encoded-Profile"] = cert
+    if "ProvisionedDevices" in plist:
+        plist["ProvisionedDevices"] = sorted(plist["ProvisionedDevices"])
 
     plistlib.dump(plist, sys.stdout.buffer, sort_keys=True)
 except subprocess.CalledProcessError:


### PR DESCRIPTION
This order can change randomly when updating profiles, users have no
control of it, might as well sort it.
